### PR TITLE
ResourceManager must be bind to ctx

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,5 +5,5 @@ version: '3'
 tasks:
   test:
     cmds:
-      - go test -cover ./... -coverprofile=coverage.out
+      - go test -cover ./... -coverprofile=coverage.out -timeout 10s
       - go tool cover -html=coverage.out -o coverage.html


### PR DESCRIPTION
When introducing this to an existing application (that uses google/wire), handling the ResourceManager was annoying, so I decided to include it in ctx.